### PR TITLE
pagebreak: add support for Typst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ FILTER_FILE := $(wildcard *.lua)
 DIFF ?= diff
 PANDOC ?= pandoc
 
-test: test-adoc test-html test-ms test-no-form-feed.html
+test: test-adoc test-html test-ms test-typst test-no-form-feed.html
 
 test-%: $(FILTER_FILE) test/input.md test/test-%.yaml
 	@$(PANDOC) --defaults test/test-$*.yaml | \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Fully supported output formats are:
 - Docx,
 - EPUB,
 - groff ms,
+- Typst
 - HTML, and
 - LaTeX.
 

--- a/pagebreak.lua
+++ b/pagebreak.lua
@@ -26,7 +26,8 @@ local default_pagebreaks = {
   latex = '\\newpage{}',
   ms = '.bp',
   ooxml = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>',
-  odt = '<text:p text:style-name="Pagebreak"/>'
+  odt = '<text:p text:style-name="Pagebreak"/>',
+  typst = '#pagebreak()\n\n'
 }
 
 local function pagebreak_from_config (config)
@@ -66,6 +67,8 @@ local function newpage(format, pagebreak)
     return pandoc.RawBlock('ms', pagebreak.ms)
   elseif format:match 'odt' then
     return pandoc.RawBlock('opendocument', pagebreak.odt)
+  elseif format:match 'typst' then
+    return pandoc.RawBlock('typst', pagebreak.typst)
   else
     -- fall back to insert a form feed character
     return pandoc.Para{pandoc.Str '\f'}

--- a/test/expected.typst
+++ b/test/expected.typst
@@ -1,0 +1,14 @@
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec
+hendrerit tempor tellus. Donec pretium posuere tellus.
+
+#pagebreak()
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus. Nulla posuere. Donec vitae dolor.
+
+#pagebreak()
+
+Pellentesque dapibus suscipit ligula. Donec posuere augue in quam.
+Suspendisse potenti.
+
+Final paragraph without a preceding pagebreak.

--- a/test/test-typst.yaml
+++ b/test/test-typst.yaml
@@ -1,0 +1,9 @@
+input-files: [test/input.md]
+to: typst
+filters:
+  - pagebreak.lua
+
+metadata:
+  pagebreak:
+    break-on:
+      form-feed: true


### PR DESCRIPTION
This adds support for [Typst](https://typst.app/) to the filter.