### PR TITLE
Add break-on.plaintext-command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ reference document (Configuration).
 In all other formats, the page break is represented using the
 form feed character.
 
-Input support is enabled (by default) with: _markdown_ and _opml_ formats.  
-If you want to enable another input format, go to [raw_tex](https://pandoc.org/MANUAL.html#extension-raw_tex) and  
-hover over `±` to check which formats support the extension,  
-because this filter is based on that extension.  
+Note that not all input formats support the `raw_tex` format
+extension, which is required to use the filter in the default
+configuration. Enable the `break-on.plaintext-command` option to
+use this filter with if `raw_tex` is unavailable.
 
 Usage
 -----
@@ -74,6 +74,9 @@ pagebreak:
     # Treat paragraphs that contain just a form feed
     # character as pagebreak markers.
     form-feed: true
+    # Allow plaintext commands, i.e., respect LaTeX newpage
+    # commands even if they are not in a raw TeX block.
+    plaintext-command: true
 
   # Use a div with this class instead of hard-coded CSS
   html-class: 'page-break'
@@ -90,6 +93,11 @@ Currently supported options:
   form feed characters with page breaks. Enabling option can have
   a significant performance impact for large documents and is
   therefore *disabled by default*.
+
+- `break-on.plaintext-command`: boolean value that controls
+  whether paragraphs with LaTeX commands should be interpreted as
+  pagebreak markers. Enabling this option may impact performance,
+  so it is *disabled* by default.
 
 - `html-class`: If you want to use an HTML class rather than an
   inline style set the value of the metadata key `html-class` or

--- a/test/expected.adoc
+++ b/test/expected.adoc
@@ -11,4 +11,12 @@ ridiculus mus. Nulla posuere. Donec vitae dolor.
 Pellentesque dapibus suscipit ligula. Donec posuere augue in quam.
 Suspendisse potenti.
 
+The following does not mark a pagebreak unless the interpretation of
+LaTeX commands in plain paragraphs is enabled.
+
+<<<
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus.
+
 Final paragraph without a preceding pagebreak.

--- a/test/expected.html
+++ b/test/expected.html
@@ -3,4 +3,7 @@
 <p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.</p>
 <div style="page-break-after: always;"></div>
 <p>Pellentesque dapibus suscipit ligula. Donec posuere augue in quam. Suspendisse potenti.</p>
+<p>The following does not mark a pagebreak unless the interpretation of LaTeX commands in plain paragraphs is enabled.</p>
+<p>\pagebreak</p>
+<p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
 <p>Final paragraph without a preceding pagebreak.</p>

--- a/test/expected.ms
+++ b/test/expected.ms
@@ -14,4 +14,12 @@ Pellentesque dapibus suscipit ligula.
 Donec posuere augue in quam.
 Suspendisse potenti.
 .PP
+The following does not mark a pagebreak unless the interpretation of
+LaTeX commands in plain paragraphs is enabled.
+.PP
+\[rs]pagebreak
+.PP
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus.
+.PP
 Final paragraph without a preceding pagebreak.

--- a/test/expected.no-form-feed.html
+++ b/test/expected.no-form-feed.html
@@ -3,4 +3,7 @@
 <p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.</p>
 <p></p>
 <p>Pellentesque dapibus suscipit ligula. Donec posuere augue in quam. Suspendisse potenti.</p>
+<p>The following does not mark a pagebreak unless the interpretation of LaTeX commands in plain paragraphs is enabled.</p>
+<p>\pagebreak</p>
+<p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
 <p>Final paragraph without a preceding pagebreak.</p>

--- a/test/expected.typst
+++ b/test/expected.typst
@@ -11,4 +11,12 @@ ridiculus mus. Nulla posuere. Donec vitae dolor.
 Pellentesque dapibus suscipit ligula. Donec posuere augue in quam.
 Suspendisse potenti.
 
+The following does not mark a pagebreak unless the interpretation of
+LaTeX commands in plain paragraphs is enabled.
+
+\\pagebreak
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus.
+
 Final paragraph without a preceding pagebreak.

--- a/test/input.md
+++ b/test/input.md
@@ -11,4 +11,12 @@ nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.
 Pellentesque dapibus suscipit ligula. Donec posuere augue in
 quam. Suspendisse potenti.
 
+The following does not mark a pagebreak unless the interpretation
+of LaTeX commands in plain paragraphs is enabled.
+
+\\pagebreak
+
+Cum sociis natoque penatibus et magnis dis parturient montes,
+nascetur ridiculus mus.
+
 Final paragraph without a preceding pagebreak.

--- a/test/test-adoc.yaml
+++ b/test/test-adoc.yaml
@@ -7,3 +7,4 @@ metadata:
   pagebreak:
     break-on:
       form-feed: true
+      plaintext-command: true


### PR DESCRIPTION
The new option enables the interpretation of paragraph text as LaTeX commands, thus allowing to use `\newpage` and the like without requiring the `raw_tex` extension.

Closes: #6