### PR TITLE
`is_newpage_command` should return false if arg is nil

### DIFF
--- a/pagebreak.lua
+++ b/pagebreak.lua
@@ -76,8 +76,12 @@ local function newpage(format, pagebreak)
 end
 
 --- Checks whether the given string contains a LaTeX pagebreak or
---- newpage command.
+--- newpage command. Returns false if commmand is nil
 local function is_newpage_command(command)
+  if not command then
+    return false
+  end
+
   return command:match '^\\newpage%{?%}?$'
     or command:match '^\\pagebreak%{?%}?$'
 end


### PR DESCRIPTION
When I ran this filter for my files, something in my files was making the filter pass nil to the `is_newpage_command` function. Checking if the argument is nil before trying to run a pattern match on it makes the filter more resilient.